### PR TITLE
Renames OSCCA to SCA

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/riboseinc/asciidoctor-bibliography
-  revision: 7f431ad91153a9726ba29d74efe29ea42bde3b49
+  revision: 99a7d8ca1e320d3b21f1091b7a1e82f847fc9640
   specs:
     asciidoctor-bibliography (0.7.0)
       asciidoctor (~> 1.5.6)
@@ -12,7 +12,7 @@ GIT
 
 GIT
   remote: https://github.com/riboseinc/asciidoctor-rfc
-  revision: db550d9d9072f7f3991e410b0492ee7602d0731f
+  revision: ce994e8b090bb4a979bd0eadce34f964813a269a
   specs:
     asciidoctor-rfc (0.8.0)
       asciidoctor (~> 1.5.6)

--- a/draft-oscca-cfrg-sm3.adoc
+++ b/draft-oscca-cfrg-sm3.adoc
@@ -1,14 +1,15 @@
 = The SM3 Cryptographic Hash Function
 :doctype: internet-draft
-:name: draft-oscca-cfrg-sm3-02
+:name: draft-sca-cfrg-sm3-00
 :abbrev: SM3 Cryptographic Hash
 :status: info
 :ipr: trust200902
-:submissionType: IRTF
-:area: cfrg
+:submission-type: IRTF
+:area: sec
 :intended-series: full-standard
-:workgroup: Crypto Forum Research Group
-:revdate: 2017-11-24T08:00:00Z
+:workgroup: Internet Research Task Force
+//:workgroup: Crypto Forum Research Group
+:revdate: 2017-12-15T00:00:00Z
 :fullname: Sean Shen
 :lastname: Shen
 :forename_initials: S.

--- a/references/informative/OSCCA-SM3.xml
+++ b/references/informative/OSCCA-SM3.xml
@@ -3,7 +3,7 @@
   <front>
     <title>SM3 Cryptographic Hash Algorithm</title>
     <author>
-      <organization>Organization of State Commercial Administration of China</organization>
+      <organization>Office of State Commercial Administration of China</organization>
       <address>
         <postal>
          <street>7 Dian Chang Lu, Fengtai Qu</street>

--- a/references/informative/SCA.xml
+++ b/references/informative/SCA.xml
@@ -1,8 +1,8 @@
-<reference anchor='OSCCA' target='http://www.oscca.gov.cn'>
+<reference anchor='SCA' target='http://www.sca.gov.cn'>
   <front>
-    <title>Organization of State Commercial Administration of China</title>
+    <title>State Cryptography Administration of China</title>
     <author>
-      <organization>Organization of State Commercial Administration of China</organization>
+      <organization>State Cryptography Administration</organization>
       <address>
         <postal>
          <street>7 Dian Chang Lu, Fengtai Qu</street>
@@ -12,8 +12,8 @@
          <country>People's Republic of China</country>
         </postal>
         <phone>+86 (0)10 5970-3789</phone>
-        <!--<email>contact@oscca.gov.cn</email>-->
-        <uri>http://www.oscca.gov.cn</uri>
+        <!--<email>contact@sca.gov.cn</email>-->
+        <uri>http://www.sca.gov.cn</uri>
       </address>
     </author>
     <date month='May' year='2017'/>

--- a/sections/00-abstract.adoc
+++ b/sections/00-abstract.adoc
@@ -1,8 +1,8 @@
 [abstract]
 
-This document describes the SM3 cryptographic hash algorithm
-published as GB/T 32905-2016 by the Organization of State Commercial
-Administration of China (OSCCA).
+This document describes the SM3 cryptographic hash algorithm published
+as GB/T 32905-2016 by the State Cryptography Administration of China
+(SCA).
 
 This document is a product of the Crypto Forum Research Group (CFRG).
 

--- a/sections/01-intro.adoc
+++ b/sections/01-intro.adoc
@@ -2,10 +2,10 @@
 [#introduction]
 = Introduction
 
-SM3 <<GBT.32905-2016>> <<ISO.IEC.10118-3>> is a cryptographic hash algorithm
-published by the Organization of State Commercial Administration of China <<OSCCA>>
-as an authorized cryptographic hash algorithm for the use within China.
-The algorithm is published in public.
+SM3 <<GBT.32905-2016>> <<ISO.IEC.10118-3>> is a cryptographic hash
+algorithm published by the State Cryptography Administration of China
+<<SCA>> as an authorized cryptographic hash algorithm for the use
+within China.  The algorithm is published in public.
 
 The SM3 algorithm is intended to address multiple use cases for commercial
 cryptography, including, but not limited to:
@@ -51,15 +51,16 @@ research on SM3.
 
 The SM3 algorithm was designed by Xiaoyun Wang <<WXY>> et al.
 
-It was first published by the OSCCA <<OSCCA>> in public in 2010 <<OSCCA-SM3>>,
-then published as a China industry standard in 2012 <<GMT-0004-2012>>, and
-finally published as a Chinese National Standard (GB Standard)
-<<GBT.32905-2016>> in 2016. SM3 has been standardized in <<ISO.IEC.10118-3>> by
-the International Organization for Standardization in 2017.
+It was first published by the SCA <<SCA>> (OSCCA at that time) in
+public in 2010 <<OSCCA-SM3>>, then published as a China industry
+standard in 2012 <<GMT-0004-2012>>, and finally published as a Chinese
+National Standard (GB Standard) <<GBT.32905-2016>> in 2016. SM3 has
+been standardized in <<ISO.IEC.10118-3>> by the International
+Organization for Standardization in 2017.
 
-The latest SM3 standard <<GBT.32905-2016>> was proposed by the OSCCA,
-standardized through TC 260 of the Standardization Administration of the
-People's Republic of China (SAC), and was drafted by the following
+The latest SM3 standard <<GBT.32905-2016>> was proposed by the SCA,
+standardized through TC 260 of the Standardization Administration of
+the People's Republic of China (SAC), and was drafted by the following
 individuals at Tsinghua University,
 the China Commercial Cryptography Testing Center,
 the People's Liberation Army Information Engineering University,
@@ -81,6 +82,6 @@ Center (DAS Center) of the Chinese Academy of Sciences:
 //# TODO
 
 SM3 has prevalent hardware implementations, due to its being the only
-OSCCA-approved cryptographic hash algorithm allowed for use in China
+SCA-approved cryptographic hash algorithm allowed for use in China
 <<SM3-Details>>.
 

--- a/sections/10-security.adoc
+++ b/sections/10-security.adoc
@@ -1,11 +1,11 @@
 = Security Considerations
 
-* Products and services that utilize cryptography are regulated by the OSCCA
-  <<OSCCA>>; they must be explicitly approved or certified by the OSCCA before
-  being allowed to be sold or used in China.
+* Products and services that utilize cryptography are regulated by the
+  SCA <<SCA>>; they must be explicitly approved or certified by the SCA
+  before being allowed to be sold or used in China.
 
 * SM3 <<GBT.32905-2016>> is a cryptographic hash algorithm published by the
-  OSCCA <<OSCCA>>. No formal proof of security is provided. The security
+  SCA <<SCA>>. No formal proof of security is provided. The security
   properties of SM3 are under public study. There are no known feasible attacks
   against the SM3 algorithm at the time this document is published.
 


### PR DESCRIPTION
Follows the rebranding of OSCCA to SCA, fixes #7 .